### PR TITLE
Handle missing docx library to allow adding rows

### DIFF
--- a/index.html
+++ b/index.html
@@ -256,7 +256,14 @@
   </footer>
 
   <script>
-    const { Document, Packer, Paragraph, HeadingLevel, TextRun, AlignmentType, Table, TableRow, TableCell, WidthType, BorderStyle } = docx;
+    // Guard against missing docx library so other features (like table rows) still work
+    const docxLib = window.docx;
+    let Document, Packer, Paragraph, HeadingLevel, TextRun, AlignmentType, Table, TableRow, TableCell, WidthType, BorderStyle;
+    if (docxLib) {
+      ({ Document, Packer, Paragraph, HeadingLevel, TextRun, AlignmentType, Table, TableRow, TableCell, WidthType, BorderStyle } = docxLib);
+    } else {
+      console.warn('docx library not loaded; document generation disabled.');
+    }
 
     // ---------- Helpers ----------
     function q(sel, root=document){ return root.querySelector(sel); }


### PR DESCRIPTION
## Summary
- Guard against missing docx library so table row functionality remains usable when docx fails to load

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689df2e37e40832db540c37fb2bab8d4