### PR TITLE
Fix mobile header floating issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
   </style>
 </head>
 <body class="bg-slate-50 text-slate-800">
-  <header class="bg-white border-b sticky top-0 z-10">
+  <header class="bg-white border-b fixed top-0 left-0 w-full z-10">
     <div class="max-w-7xl mx-auto px-4 py-4 flex items-center gap-3">
       <div class="w-10 h-10 rounded-2xl bg-indigo-600 text-white grid place-items-center text-xl font-bold">P</div>
       <div>
@@ -34,7 +34,7 @@
     </div>
   </header>
 
-  <main class="max-w-7xl mx-auto p-4 grid lg:grid-cols-2 gap-6">
+  <main class="max-w-7xl mx-auto p-4 pt-24 grid lg:grid-cols-2 gap-6">
     <!-- FORM -->
     <section class="bg-white rounded-2xl shadow-sm border p-4 md:p-6">
       <form id="proposalForm" class="space-y-6">


### PR DESCRIPTION
## Summary
- Keep Proposal Builder header fixed at top on scroll
- Add padding to main content so header no longer overlaps

## Testing
- `node -v >/dev/null 2>&1 && npm test || echo 'no package.json'`


------
https://chatgpt.com/codex/tasks/task_e_689ef0d45b48832dadeae39a3e016eab