### PR TITLE
Fix template upload by converting ArrayBuffer

### DIFF
--- a/index.html
+++ b/index.html
@@ -321,7 +321,9 @@
       const file = e.target.files[0];
       if (!file) return;
       try {
-        templateBuffer = await file.arrayBuffer();
+        // docx-preview expects a Uint8Array. Converting here ensures
+        // template parsing works reliably across browsers.
+        templateBuffer = new Uint8Array(await file.arrayBuffer());
         const container = document.createElement('div');
         await docx.renderAsync(templateBuffer, container, undefined, { inWrapper: false });
         templateHtml = container.innerHTML;


### PR DESCRIPTION
## Summary
- Convert uploaded template to `Uint8Array` before rendering so docx-preview can parse it
- Add clarifying comment about browser compatibility

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a44f6df148832db9c64df4330f86fc